### PR TITLE
fix: amp-bind usage detection via regex, not tag

### DIFF
--- a/lib/tags.js
+++ b/lib/tags.js
@@ -1,4 +1,4 @@
-function getTags ({
+function getTags({
   cdnBase = 'https://cdn.ampproject.org/v0/'
 }) {
   const tags = [
@@ -22,7 +22,7 @@ function getTags ({
     { tag: 'amp-autocomplete', version: '0.1' },
     { tag: 'amp-base-carousel', version: '0.1' },
     { tag: 'amp-beopinion', version: '0.1' },
-    { tag: 'amp-bind', version: '0.1' },
+    { tag: 'amp-bind', version: '0.1', regex: /<[^>]*\[.*\][^>]*>/gi }, //usage detection via <..[..]=..>
     { tag: 'amp-bodymovin-animation', version: '0.1' },
     { tag: 'amp-brid-player', version: '0.1' },
     { tag: 'amp-brightcove', version: '0.1' },
@@ -131,8 +131,10 @@ function getTags ({
   return tags
 }
 
-function detectTags (tags, html) {
-  return tags.filter(t => t.isTemplate ? html.includes(`type="${t.tag}"`) : html.includes(`<${t.tag}`))
+function detectTags(tags, html) {
+  return tags.filter(t => t.isTemplate ? html.includes(`type="${t.tag}"`) : (
+      t.regex ? html.search(t.regex) > -1 : html.includes(`<${t.tag}`)
+    ))
     .filter((t, index, self) => index === self.findIndex(t2 => (t.url === t2.url))) // filter duplicates
 }
 


### PR DESCRIPTION
amp-bind plugin must be added if the bind syntax <..[..]=..> is used